### PR TITLE
Update documentation and change external port in docker-compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,5 +24,4 @@ jobs:
           name: Run Integration Tests
           command: |
             docker cp ./ node-test-runner:./
-            docker exec node-test-runner sh -c 'npm install'
             docker exec node-test-runner sh -c 'cd ./reload-runner && TEST_HOST=qix-engine node index.js'

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can now run each script example by providing it as an argument to `npm start
 named `csv-file.qvs', run:
 
 ```sh
-npm start scripts/csv-file.qvs
+npm start csv-file.qvs
 ```
 
 This should print the table content loaded into Qlik Associative Engine to the console.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: always
     command: -S AcceptEULA=${ACCEPT_EULA}
     ports:
-      - "19076:9076"
+      - "9076:9076"
     volumes:
       - ./data:/data
   node-test-runner:

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const host = process.env.TEST_HOST || 'localhost';
 async function openSessionApp() {
   const session = enigma.create({
     schema,
-    url: `ws://${host}:19076/app/engineData`,
+    url: `ws://${host}:9076/app/engineData`,
     createSocket: url => new WebSocket(url),
   });
   const qix = await session.open();

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const host = process.env.TEST_HOST || 'localhost';
 async function openSessionApp() {
   const session = enigma.create({
     schema,
-    url: `ws://${host}:9076/app/engineData`,
+    url: `ws://${host}:19076/app/engineData`,
     createSocket: url => new WebSocket(url),
   });
   const qix = await session.open();


### PR DESCRIPTION
The documentation regarding passing script as an argument was incorrect since `index.js` already added the `scripts` folder to the path.

Also `index.js` assumes that engine is on port 9076 which works in circle ci since then the external port is not used. Since the docker-compose file sets external port as 19076 the example did not work locally.

This closes #31 